### PR TITLE
fix: Fix config

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -1,4 +1,4 @@
 port = 8000
 address="localhost"
 botname = "ai-chann"
-api_token = "api_token"
+github_api_key = "api_token"


### PR DESCRIPTION
When I ran ai-chan, she said like this.
```
Failed load config file: missing field `github_api_key`
```

So I renamed `api_token` to `github_api_key`, she worked fine.
